### PR TITLE
docs: 更新图片链接为GitHub原始文件地址

### DIFF
--- a/case/20250324-24f24c.html
+++ b/case/20250324-24f24c.html
@@ -384,7 +384,7 @@
       <section id="overview" class="mb-16">
         <h2 class="text-3xl font-bold text-gray-800 mb-8">漏洞影响链</h2>
         <img
-          src="./assets/20250324-24f24c.png"
+          src="https://github.com/ctkqiang/bug-bounty-journal/blob/main/assets/20250324-24f24c.png?raw=true"
           class="rounded-lg shadow-xl w-full mb-8"
           alt="数据泄露影响链示意图"
         />


### PR DESCRIPTION
将本地图片路径替换为GitHub原始文件地址，确保图片在远程访问时能正常显示