### PR TITLE
docs: 更新漏洞报告中的图片链接和新增影响链部分

### DIFF
--- a/case/20250326-enVzY29mZmVl.html
+++ b/case/20250326-enVzY29mZmVl.html
@@ -27,7 +27,7 @@
     <meta property="og:type" content="article" />
     <meta
       property="og:image"
-      content="https://github.com/ctkqiang/bug-bounty-journal/blob/main/assets/20250326-marine.png?raw=true"
+      content="https://github.com/ctkqiang/bug-bounty-journal/blob/main/assets/20250326-enVzY29mZmVl-manifest.png?raw=true"
     />
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
@@ -41,7 +41,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://github.com/ctkqiang/bug-bounty-journal/blob/main/assets/20250326-marine.png?raw=true"
+      content="https://github.com/ctkqiang/bug-bounty-journal/blob/main/assets/20250326-enVzY29mZmVl-manifest.png?raw=true"
     />
     <script src="https://cdn.tailwindcss.com"></script>
     <link
@@ -261,6 +261,16 @@
               </div>
           </div>
         </section> -->
+
+        <section id="overview" class="mb-16">
+        <h2 class="text-3xl font-bold text-gray-800 mb-8">漏洞影响链</h2>
+        <img
+          src="https://github.com/ctkqiang/bug-bounty-journal/blob/main/assets/20250326-enVzY29mZmVl-manifest.png?raw=true"
+          class="rounded-lg shadow-xl w-full mb-8"
+          alt="数据泄露影响链示意图"
+        />
+        </div>
+      </section>
 
         <!-- After the Overview Section -->
         <div class="bg-white p-8 rounded-lg shadow-md mb-8">


### PR DESCRIPTION
更新了OG和Twitter Card的图片链接，并新增了漏洞影响链部分，以更清晰地展示数据泄露的影响链